### PR TITLE
Add infinite pagination for PodcastDetail

### DIFF
--- a/src/renderer/controller/PodcastDetailController.js
+++ b/src/renderer/controller/PodcastDetailController.js
@@ -4,6 +4,7 @@ const PodcastController = remote.require('./browser/controller/PodcastController
 
 app.controller('PodcastDetailController', ['$scope', '$rootScope', '$routeParams', '$location', ($scope, $rootScope, $routeParams, $location) => {
 
+  let paginate = 20
   $scope.podcast = Podcast.find({id: $routeParams.id})
   $scope.episodes = Episode
       .chain()
@@ -13,6 +14,19 @@ app.controller('PodcastDetailController', ['$scope', '$rootScope', '$routeParams
       .take(20)
       .value();
 
+  const moreEpisodes = function() {
+    let newEps = Episode
+        .chain()
+        .filter({podcast_id: $routeParams.id})
+        .sortBy('published_time')
+        .reverse()
+        .take($scope.episodes.length + paginate)
+        .slice($scope.episodes.length)
+        .value()
+    newEps.forEach(i => $scope.episodes.push(i))
+    $scope.$apply()
+  }
+
   $scope.unsubscribe = () => {
     PodcastController.remove($scope.podcast.id)
     $location.path('/recent')
@@ -21,5 +35,11 @@ app.controller('PodcastDetailController', ['$scope', '$rootScope', '$routeParams
   $scope.play = (episode) => {
     $rootScope.$broadcast('episode.play', episode);
   }
+
+  $('.podcast-detail-list').parents('.pane.content').scroll(() => {
+    if($('.podcast-detail-list').height() - 300 <= $(this).scrollTop()) {
+      moreEpisodes()
+    }
+  })
 
 }]);

--- a/src/renderer/view/podcast.html
+++ b/src/renderer/view/podcast.html
@@ -6,7 +6,7 @@
   </div>
   <button ng-click="unsubscribe()" class="btn btn-large btn-default">Unsubscribe</button>
 </header>
-<div class="content">
+<div class="content podcast-detail-list">
   <article class="podcast-item" ng-repeat="episode in episodes">
     <figure ng-hide="!episode.hasOwnProperty('image')">
       <img ng-src="{{episode.image}}" alt="">


### PR DESCRIPTION
This commit introduces a very simple infinite scroll implemented with jQuery. We couldn't use ng-infinite-scroll because of our UI architecture with Photon that doesn't allow ng-infinite-scroll work properly.

Closes #18
